### PR TITLE
[React 15.5] Fix PropTypes warnings by using prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,8 @@
   "peerDependencies": {
     "react": "^15.0.0",
     "react-dom": "^15.0.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
   }
 }

--- a/src/portal.js
+++ b/src/portal.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDom from 'react-dom';
 
 class Portal extends Component {
@@ -27,7 +28,7 @@ class Portal extends Component {
 }
 
 Portal.propTypes = {
-  children: React.PropTypes.node, // eslint-disable-line
+  children: PropTypes.node, // eslint-disable-line
 };
 
 export default Portal;


### PR DESCRIPTION
Pretty straightforward fix, just added prop-types as a dependency, and import PropTypes from there instead of the react package.
See this post for details
https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html