### PR TITLE
Add support to server side rendering.

### DIFF
--- a/src/portal.js
+++ b/src/portal.js
@@ -6,9 +6,11 @@ const useCreatePortal = typeof ReactDom.createPortal === 'function';
 
 class Portal extends Component {
   componentWillMount() {
-    this.popup = document.createElement('div');
-    document.body.appendChild(this.popup);
-    this.renderLayer();
+    if (typeof window !== 'undefined') {
+      this.popup = document.createElement('div');
+      document.body.appendChild(this.popup);
+      this.renderLayer();
+    }
   }
 
   componentDidUpdate() {


### PR DESCRIPTION
In your current version, the portal breaks in server side. 
With this check you can bypass the crash by "supporting" server side rendering.